### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/mouhsineelachbi/nodeauth/security/code-scanning/3](https://github.com/mouhsineelachbi/nodeauth/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions:` block that limits the `GITHUB_TOKEN` to the minimal scopes required. For a simple Node.js CI workflow that only checks out code and runs tests, `contents: read` is usually sufficient. This should be added either at the top level (so it applies to all jobs) or within the specific job definition.

For this file, the least intrusive fix without changing existing functionality is to add a workflow-level `permissions:` block directly under the `name: Node.js CI` line, before the `on:` trigger. This will apply to all jobs (here, just `build`) and constrain the `GITHUB_TOKEN` to read repository contents only. No new imports or external dependencies are needed; we only modify the YAML.

Concretely, in `.github/workflows/nodejs.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 4 and 6 in the provided snippet. No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
